### PR TITLE
Fixed issues with vector type declarations.

### DIFF
--- a/godot/vector2.go
+++ b/godot/vector2.go
@@ -33,11 +33,12 @@ type Vector2 struct {
 	vector2 *C.godot_vector2
 }
 
-func (v *Vector2) Abs() Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_abs(v.vector2)
+func (v *Vector2) Abs() *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_abs(v.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //Angle returns the result of atan2 when called with the Vector’s x and y as parameters
@@ -52,6 +53,7 @@ func (v *Vector2) Angle() float64 {
 
 //AngleTo returns the angle in radians between the two vectors.
 func (v *Vector2) AngleTo(to Vector2) float64 {
+
 	angleTo := C.godot_vector2_angle_to(v.vector2, to.vector2)
 	return godotRealAsReal(angleTo)
 }
@@ -64,28 +66,36 @@ func (v *Vector2) AngleToPoint(to Vector2) float64 {
 	return godotRealAsReal(angleToPoint)
 }
 
-//Bounce is not documented in the godot library yet.
-func (v *Vector2) Bounce(with Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_bounce(v.vector2, with.vector2)
+//AsString returns a string.
+func (v *Vector2) AsString() string {
+	asString := C.godot_vector2_as_string(v.vector2)
+	return godotStringAsString(&asString)
+}
 
-	return newVec2
+//Bounce is not documented in the godot library yet.
+func (v *Vector2) Bounce(with Vector2) *Vector2 {
+
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_bounce(v.vector2, with.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //Clamped replaces v.vector2 with a new vector2 that is equivelant to v.vector2 * length
-func (v *Vector2) Clamped(length float64) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_clamped(realAsGodotReal(length))
+func (v *Vector2) Clamped(length float64) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_clamped(v.vector2, realAsGodotReal(length))
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //CubicInterpolate Cubicly interpolates between this Vector and “b”, using “pre_a”
 //and “post_b” as handles, and returning the result at position “t”.
-func (v *Vector2) CubicInterpolate(b Vector2, preA Vector2, postB Vector2, t float64) Vector2 {
+func (v *Vector2) CubicInterpolate(b Vector2, preA Vector2, postB Vector2, t float64) *Vector2 {
 
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_cubic_interpolate(
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_cubic_interpolate(
 		v.vector2,
 		b.vector2,
 		preA.vector2,
@@ -93,7 +103,7 @@ func (v *Vector2) CubicInterpolate(b Vector2, preA Vector2, postB Vector2, t flo
 		realAsGodotReal(t),
 	)
 
-	return newVec2
+	return &Vector2{vector2: &newVec2}
 }
 
 //DistanceSquaredTo returns the squared distance to vector “b”. Prefer this
@@ -120,12 +130,12 @@ func (v *Vector2) Dot(with Vector2) float64 {
 }
 
 //Floor removes the fractional part of x and y.
-func (v *Vector2) Floor() Vector2 {
+func (v *Vector2) Floor() *Vector2 {
 
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_floor(v.vector2)
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_floor(v.vector2)
 
-	return newVec2
+	return &Vector2{vector2: &newVec2}
 }
 
 //GetAspect returns the ratio of X to Y.
@@ -161,47 +171,52 @@ func (v *Vector2) LengthSquared() float64 {
 
 //LinearInterpolate returns the result of the linear interpolation between this
 //vector and “b”, by amount “t”.
-func (v *Vector2) LinearInterpolate(b Vector2, t float64) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_linear_interpolate(
+func (v *Vector2) LinearInterpolate(b Vector2, t float64) *Vector2 {
+
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_linear_interpolate(
 		v.vector2,
 		b.vector2,
 		realAsGodotReal(t),
 	)
 
-	return newVec2
+	return &Vector2{vector2: &newVec2}
 }
 
 //Normalized returns a normalized vector to unit length.
-func (v *Vector2) Normalized() Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_normalized(v.vector2)
+func (v *Vector2) Normalized() *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_normalized(v.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorAdd adds the current vector and with.
-func (v *Vector2) OperatorAdd(with Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_add(v.vector2, with.vector2)
+func (v *Vector2) OperatorAdd(with Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_add(v.vector2, with.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorDivideScalar divides the current vector by with.
-func (v *Vector2) OperatorDivideScalar(with float64) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_divide_scalar(v.vector2, realAsGodotReal(with))
+func (v *Vector2) OperatorDivideScalar(with float64) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_divide_scalar(v.vector2, realAsGodotReal(with))
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorDivideVector multiplys the current vector and with.
-func (v *Vector2) OperatorDivideVector(with Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_divide_vector(v.vector2, with.vector2)
+func (v *Vector2) OperatorDivideVector(with Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_divide_vector(v.vector2, with.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorEqual compares the current vector and with. Returns true if v.vector2 == with.vector2
@@ -219,51 +234,57 @@ func (v *Vector2) OperatorLess(with Vector2) bool {
 }
 
 //OperatorMultiplyScalar multiplys the current vector by with.
-func (v *Vector2) OperatorMultiplyScalar(with float64) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_multiply_scalar(v.vector2, realAsGodotReal(with))
+func (v *Vector2) OperatorMultiplyScalar(with float64) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_multiply_scalar(v.vector2, realAsGodotReal(with))
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorMultiplyVector multiplys the current vector and with.
-func (v *Vector2) OperatorMultiplyVector(with Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_multiply_vector(v.vector2, with.vector2)
+func (v *Vector2) OperatorMultiplyVector(with Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_multiply_vector(v.vector2, with.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorNeg returns -v.vector2.
-func (v *Vector2) OperatorNeg() Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_neg(v.vector2)
+func (v *Vector2) OperatorNeg() *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_neg(v.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //OperatorSubtract subtracts the current vector and with.
-func (v *Vector2) OperatorSubtract(with Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_operator_substract(v.vector2, with.vector2)
+func (v *Vector2) OperatorSubtract(with Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_operator_substract(v.vector2, with.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //Reflect is like “slide”, but reflects the Vector instead of continuing along the wall.
-func (v *Vector2) Reflect(vec Vector2) Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_reflect(v.vector2, vec.vector2)
+func (v *Vector2) Reflect(vec Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_reflect(v.vector2, vec.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //Rotated rotates the vector by “phi” radians.
-func (v *Vector2) Rotated(phi float64) {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_rotated(v.vector2, realAsGodotReal(phi))
+func (v *Vector2) Rotated(phi float64) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_rotated(v.vector2, realAsGodotReal(phi))
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //SetX changes v.vector2.x to the value specified.
@@ -277,31 +298,28 @@ func (v *Vector2) SetY(y float64) {
 }
 
 //Slide slides the vector by the other vector.
-func (v *Vector2) Slide(vec Vector2) {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_slide(v.vector2, vec.vector2)
+func (v *Vector2) Slide(vec Vector2) *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_slide(v.vector2, vec.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }
 
 //Snapped snaps the vector to a grid with the given size.
-func (v *Vector2) Snapped(by Vector2) {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_snapped(v.vector2, by.vector2)
+func (v *Vector2) Snapped(by Vector2) *Vector2 {
 
-	return newVec2
-}
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_snapped(v.vector2, by.vector2)
 
-//AsString returns a string.
-func (v *Vector2) AsString() string {
-	asString := C.godot_vector2_as_string(v.vector2)
-	return godotStringAsString(asString)
+	return &Vector2{vector2: &newVec2}
 }
 
 //Tangent returns a perpendicular vector.
-func (v *Vector2) Tangent() Vector2 {
-	var newVec2 Vector2
-	newVec2.vector2 = C.godot_vector2_tangent(v.vector2)
+func (v *Vector2) Tangent() *Vector2 {
 
-	return newVec2
+	var newVec2 C.godot_vector2
+	newVec2 = C.godot_vector2_tangent(v.vector2)
+
+	return &Vector2{vector2: &newVec2}
 }

--- a/godot/vector3.go
+++ b/godot/vector3.go
@@ -42,11 +42,12 @@ type Vector3 struct {
 	vector3 *C.godot_vector3
 }
 
-func (v *Vector3) Abs() Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_abs(v.vector3)
+func (v *Vector3) Abs() *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_abs(v.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //AngleTo returns the angle in radians between the two vectors.
@@ -57,43 +58,44 @@ func (v *Vector3) AngleTo(to Vector3) float64 {
 
 //AsString returns a string.
 func (v *Vector3) AsString() string {
+
 	asString := C.godot_vector3_as_string(v.vector3)
-	return godotStringAsString(asString)
+	return godotStringAsString(&asString)
 }
 
 //Bounce is not documented in the godot library yet.
-func (v *Vector3) Bounce(with Vector3) Vector3 {
+func (v *Vector3) Bounce(with Vector3) *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_bounce(v.vector3, with.vector3)
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_bounce(v.vector3, with.vector3)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //Ceil returns a new vector with all components rounded up.
-func (v *Vector3) Ceil() Vector3 {
+func (v *Vector3) Ceil() *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_ceil(v.vector3)
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_ceil(v.vector3)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //Cross returns the cross product with b.
-func (v *Vector3) Cross(b Vector3) Vector3 {
+func (v *Vector3) Cross(b Vector3) *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_cross(v.vector3, b.vector3)
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_cross(v.vector3, b.vector3)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //CubicInterpolate Cubicly interpolates between this Vector and “b”, using “pre_a”
 //and “post_b” as handles, and returning the result at position “t”.
-func (v *Vector3) CubicInterpolate(b Vector3, preA Vector3, postB Vector3, t float64) Vector3 {
+func (v *Vector3) CubicInterpolate(b Vector3, preA Vector3, postB Vector3, t float64) *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_cubic_interpolate(
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_cubic_interpolate(
 		v.vector3,
 		b.vector3,
 		preA.vector3,
@@ -101,7 +103,7 @@ func (v *Vector3) CubicInterpolate(b Vector3, preA Vector3, postB Vector3, t flo
 		realAsGodotReal(t),
 	)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //DistanceSquaredTo returns the squared distance to vector “b”. Prefer this
@@ -128,12 +130,12 @@ func (v *Vector3) Dot(with Vector3) float64 {
 }
 
 //Floor removes the fractional part of x and y.
-func (v *Vector3) Floor() Vector3 {
+func (v *Vector3) Floor() *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_floor(v.vector3)
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_floor(v.vector3)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 ///GetAxis returns the value of the supplied axis
@@ -143,12 +145,12 @@ func (v *Vector3) GetAxis(axis Vec3Axis) float64 {
 
 //Inverse returns the inverse of the vector. This is the same as i
 //Vector3( 1.0 / x, 1.0 / y, 1.0 / z )
-func (v *Vector3) Inverse() Vector3 {
+func (v *Vector3) Inverse() *Vector3 {
 
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_inverse(v.vector3)
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_inverse(v.vector3)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //IsNormalized
@@ -170,15 +172,16 @@ func (v *Vector3) LengthSquared() float64 {
 
 //LinearInterpolate returns the result of the linear interpolation between this
 //vector and “b”, by amount “t”.
-func (v *Vector3) LinearInterpolate(b Vector3, t float64) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_linear_interpolate(
+func (v *Vector3) LinearInterpolate(b Vector3, t float64) *Vector3 {
+
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_linear_interpolate(
 		v.vector3,
 		b.vector3,
 		realAsGodotReal(t),
 	)
 
-	return newVec3
+	return &Vector3{vector3: &newVec3}
 }
 
 //MaxAxis returns VECTOR3_AXIS_X, VECTOR3_AXIS_Y or VECTOR3_AXIS_Z depending on
@@ -194,35 +197,39 @@ func (v *Vector3) MinAxis() int {
 }
 
 //Normalized returns a normalized vector to unit length.
-func (v *Vector3) Normalized() Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_normalized(v.vector3)
+func (v *Vector3) Normalized() *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_normalized(v.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorAdd adds the current vector and with.
-func (v *Vector3) OperatorAdd(with Vector3) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_add(v.vector3, with.vector3)
+func (v *Vector3) OperatorAdd(with Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_add(v.vector3, with.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorDivideScalar divides the current vector by with.
-func (v *Vector3) OperatorDivideScalar(with float64) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_divide_scalar(v.vector3, realAsGodotReal(with))
+func (v *Vector3) OperatorDivideScalar(with float64) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_divide_scalar(v.vector3, realAsGodotReal(with))
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorDivideVector multiplys the current vector and with.
-func (v *Vector3) OperatorDivideVector(with Vector3) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_divide_vector(v.vector3, with.vector3)
+func (v *Vector3) OperatorDivideVector(with Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_divide_vector(v.vector3, with.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorEqual compares the current vector and with. Returns true if v.vector3 == with.vector3
@@ -240,59 +247,67 @@ func (v *Vector3) OperatorLess(with Vector3) bool {
 }
 
 //OperatorMultiplyScalar multiplys the current vector by with.
-func (v *Vector3) OperatorMultiplyScalar(with float64) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_multiply_scalar(v.vector3, realAsGodotReal(with))
+func (v *Vector3) OperatorMultiplyScalar(with float64) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_multiply_scalar(v.vector3, realAsGodotReal(with))
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorMultiplyVector multiplys the current vector and with.
-func (v *Vector3) OperatorMultiplyVector(with Vector3) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_multiply_vector(v.vector3, with.vector3)
+func (v *Vector3) OperatorMultiplyVector(with Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_multiply_vector(v.vector3, with.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorNeg returns -v.vector3.
-func (v *Vector3) OperatorNeg() Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_neg(v.vector3)
+func (v *Vector3) OperatorNeg() *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_neg(v.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //OperatorSubtract subtracts the current vector and with.
-func (v *Vector3) OperatorSubtract(with Vector3) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_operator_substract(v.vector3, with.vector3)
+func (v *Vector3) OperatorSubtract(with Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_operator_substract(v.vector3, with.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
+/*
 //Outer
 func (v *Vector3) Outer(with Vector3) Basis {
 
 	outer := C.godot_vector3_outer(v.vector3, with.vector3)
 
-	return outer
+	return outer //TODO: godotBasisAsBasis(outer)
 }
+*/
 
 //Reflect is like “slide”, but reflects the Vector instead of continuing along the wall.
-func (v *Vector3) Reflect(vec Vector3) Vector3 {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_reflect(v.vector3, vec.vector3)
+func (v *Vector3) Reflect(vec Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_reflect(v.vector3, vec.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //Rotated rotates the vector by “phi” radians.
-func (v *Vector3) Rotated(phi float64) {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_rotated(v.vector3, realAsGodotReal(phi))
+func (v *Vector3) Rotated(by Vector3, phi float64) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_rotated(v.vector3, by.vector3, realAsGodotReal(phi))
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //SetAxis changes the specified axis to the specified value.
@@ -301,26 +316,29 @@ func (v *Vector3) SetAxis(axis Vec3Axis, val float64) {
 }
 
 //Slide slides the vector by the other vector.
-func (v *Vector3) Slide(vec Vector3) {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_slide(v.vector3, vec.vector3)
+func (v *Vector3) Slide(by Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_slide(v.vector3, by.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
 //Snapped snaps the vector to a grid with the given size.
-func (v *Vector3) Snapped(by Vector3) {
-	var newVec3 Vector3
-	newVec3.vector3 = C.godot_vector3_snapped(v.vector3, by.vector3)
+func (v *Vector3) Snapped(by Vector3) *Vector3 {
 
-	return newVec3
+	var newVec3 C.godot_vector3
+	newVec3 = C.godot_vector3_snapped(v.vector3, by.vector3)
+
+	return &Vector3{vector3: &newVec3}
 }
 
+/*
 //ToDiagonalMatrix
-
 func (v *Vector3) ToDiagonalMatrix() Basis {
 
-	todiagonalmatrix := C.godot_vector3_to_diagonal_matrix(v.vector3)
+	tdm := C.godot_vector3_to_diagonal_matrix(v.vector3)
 
-	return todiagonalmatrix
+	return tdm //TODO: godotBasisAsBasis(tdm)
 }
+*/


### PR DESCRIPTION
Renamed some function variables to be in line with established convention.
Some functions were not returning a *Vector2 or *Vector3 at all.
AsString has been properly alphabetized in vector2.go
Disabled some functions in vector3.go until Basis type is implemented.